### PR TITLE
Support grouped WHERE predicates

### DIFF
--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -239,6 +239,23 @@ func TestSelectLikePredicate(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("expected 1 rows, got %d", count)
 	}
+
+	rows, err = db.Query("SELECT * FROM resource WHERE (name LIKE 'some%' OR name LIKE 'other%') LIMIT 50")
+	if err != nil {
+		t.Fatalf("sql.Query error: %s", err)
+	}
+	defer rows.Close()
+
+	count = 0
+	for rows.Next() {
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err error: %s", err)
+	}
+	if count != 4 {
+		t.Fatalf("expected 4 rows, got %d", count)
+	}
 }
 
 func TestSelectCamelCase(t *testing.T) {

--- a/engine/executor/tx.go
+++ b/engine/executor/tx.go
@@ -321,6 +321,7 @@ func (t *Tx) getPredicatesWithODBCIdx(decl []*parser.Decl, schema, fromTableName
 		var inDecl *parser.Decl
 		var isNot bool
 		var attrs []*parser.Decl
+		var hasLogical bool
 
 		for _, child := range cond.Decl {
 			if child.Token == parser.InToken {
@@ -332,6 +333,8 @@ func (t *Tx) getPredicatesWithODBCIdx(decl []*parser.Decl, schema, fromTableName
 					inDecl = child.Decl[0]
 				}
 				break
+			} else if child.Token == parser.AndToken || child.Token == parser.OrToken {
+				hasLogical = true
 			} else {
 				attrs = append(attrs, child)
 			}
@@ -339,6 +342,14 @@ func (t *Tx) getPredicatesWithODBCIdx(decl []*parser.Decl, schema, fromTableName
 
 		if inDecl != nil && len(attrs) > 0 {
 			p, err := tupleInExecutor(fromTableName, attrs, inDecl, isNot, aliases, args)
+			if err != nil {
+				return nil, err
+			}
+			return p, nil
+		}
+
+		if hasLogical {
+			p, err := t.getPredicates(cond.Decl, schema, fromTableName, args, aliases)
 			if err != nil {
 				return nil, err
 			}

--- a/engine/parser/where.go
+++ b/engine/parser/where.go
@@ -89,6 +89,35 @@ func (p *parser) parseCondition() (*Decl, error) {
 			return nil, err
 		}
 
+		if p.hasLogicalOperatorUntilClosingBracket() {
+			groupDecl := &Decl{Token: BracketOpeningToken, Lexeme: "("}
+			for {
+				if p.is(BracketClosingToken) {
+					_, err := p.consumeToken(BracketClosingToken)
+					if err != nil {
+						return nil, err
+					}
+					break
+				}
+
+				condDecl, err := p.parseCondition()
+				if err != nil {
+					return nil, err
+				}
+				groupDecl.Add(condDecl)
+
+				if p.is(AndToken, OrToken) {
+					linkDecl, err := p.consumeToken(p.cur().Token)
+					if err != nil {
+						return nil, err
+					}
+					groupDecl.Add(linkDecl)
+				}
+			}
+
+			return groupDecl, nil
+		}
+
 		// Parse first attribute
 		firstAttr, err := p.parseAttribute()
 		if err != nil {
@@ -355,4 +384,24 @@ func (p *parser) parseCondition() (*Decl, error) {
 	attributeDecl.Add(valueDecl)
 
 	return attributeDecl, nil
+}
+
+func (p *parser) hasLogicalOperatorUntilClosingBracket() bool {
+	depth := 0
+	for i := p.index; i < len(p.tokens); i++ {
+		switch p.tokens[i].Token {
+		case BracketOpeningToken:
+			depth++
+		case BracketClosingToken:
+			if depth == 0 {
+				return false
+			}
+			depth--
+		case AndToken, OrToken:
+			if depth == 0 {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/engine/parser/where_test.go
+++ b/engine/parser/where_test.go
@@ -20,6 +20,7 @@ func TestWhereLikeExpressions(t *testing.T) {
 		`SELECT * FROM resources WHERE name LIKE 'some%'`,
 		`SELECT * FROM resources WHERE name LIKE 'some_thing%'`,
 		`SELECT * FROM resources WHERE name LIKE 'some%' OR name LIKE 'other%' LIMIT 50`,
+		`SELECT * FROM resources WHERE (name LIKE 'some%' OR name LIKE 'other%') LIMIT 50`,
 	}
 
 	for _, q := range queries {


### PR DESCRIPTION
## Summary
- parse grouped WHERE predicates with AND/OR inside parentheses
- evaluate grouped predicates in executor
- add parser and driver tests for grouped LIKE

## Testing
- go test ./engine/parser -run TestWhereLikeExpressions -v
- go test ./driver -run TestSelectLikePredicate -v