### PR TITLE
Fix HashIndex losing rows when multiple entries share the same hash key

### DIFF
--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -3971,3 +3971,51 @@ func TestTypeAliasInsert(t *testing.T) {
 		t.Fatalf("expected 100, got %d", readValue)
 	}
 }
+
+func TestHashIndexMultipleRowsSameFK(t *testing.T) {
+	db, err := sql.Open("ramsql", "TestHashIndexMultipleRowsSameFK")
+	if err != nil {
+		t.Fatalf("cannot open db: %s", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(`CREATE TABLE parent (id BIGINT PRIMARY KEY)`)
+	if err != nil {
+		t.Fatalf("create parent: %s", err)
+	}
+	_, err = db.Exec(`CREATE TABLE child (id BIGINT, parent_id BIGINT, FOREIGN KEY (parent_id) REFERENCES parent(id))`)
+	if err != nil {
+		t.Fatalf("create child: %s", err)
+	}
+	_, err = db.Exec(`INSERT INTO parent (id) VALUES (1)`)
+	if err != nil {
+		t.Fatalf("insert parent: %s", err)
+	}
+	for i := int64(1); i <= 3; i++ {
+		_, err = db.Exec(`INSERT INTO child (id, parent_id) VALUES ($1, 1)`, i)
+		if err != nil {
+			t.Fatalf("insert child %d: %s", i, err)
+		}
+	}
+
+	rows, err := db.Query(`SELECT id FROM child WHERE parent_id = 1`)
+	if err != nil {
+		t.Fatalf("select: %s", err)
+	}
+	defer rows.Close()
+
+	var count int
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan: %s", err)
+		}
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows err: %s", err)
+	}
+	if count != 3 {
+		t.Fatalf("expected 3 rows, got %d", count)
+	}
+}

--- a/engine/agnostic/index.go
+++ b/engine/agnostic/index.go
@@ -21,6 +21,7 @@ type Index interface {
 	Name() string
 	CanSourceWith(p Predicate) (bool, int64)
 	Get(values []any) (*list.Element, error)
+	GetAll(values []any) ([]*list.Element, error)
 }
 
 type HashIndex struct {
@@ -29,7 +30,7 @@ type HashIndex struct {
 	relAttrs  []string
 	attrs     []int
 	attrsName []string
-	m         map[uint64]uintptr
+	m         map[uint64][]uintptr
 
 	maphash.Hash
 }
@@ -40,7 +41,7 @@ func NewHashIndex(name string, relName string, relAttrs []Attribute, attrsName [
 		relName:   relName,
 		attrs:     attrs,
 		attrsName: attrsName,
-		m:         make(map[uint64]uintptr),
+		m:         make(map[uint64][]uintptr),
 	}
 	h.SetSeed(maphash.MakeSeed())
 	for _, a := range relAttrs {
@@ -64,7 +65,7 @@ func (h *HashIndex) Add(e *list.Element) {
 	}
 	sum := h.Sum64()
 	h.Reset()
-	h.m[sum] = uintptr(unsafe.Pointer(e))
+	h.m[sum] = append(h.m[sum], uintptr(unsafe.Pointer(e)))
 }
 
 func (h *HashIndex) Remove(e *list.Element) {
@@ -78,7 +79,19 @@ func (h *HashIndex) Remove(e *list.Element) {
 	}
 	sum := h.Sum64()
 	h.Reset()
-	delete(h.m, sum)
+	ptrs := h.m[sum]
+	target := uintptr(unsafe.Pointer(e))
+	for i, p := range ptrs {
+		if p == target {
+			ptrs = append(ptrs[:i], ptrs[i+1:]...)
+			break
+		}
+	}
+	if len(ptrs) == 0 {
+		delete(h.m, sum)
+	} else {
+		h.m[sum] = ptrs
+	}
 }
 
 func (h *HashIndex) Get(values []any) (*list.Element, error) {
@@ -92,19 +105,37 @@ func (h *HashIndex) Get(values []any) (*list.Element, error) {
 	sum := h.Sum64()
 	h.Reset()
 
-	var t *list.Element
-	ptr, ok := h.m[sum]
+	ptrs, ok := h.m[sum]
+	if !ok || len(ptrs) == 0 {
+		return nil, nil
+	}
+	return (*list.Element)(unsafe.Pointer(ptrs[0])), nil
+}
+
+func (h *HashIndex) GetAll(values []any) ([]*list.Element, error) {
+	for _, v := range values {
+		if v == nil {
+			h.Write([]byte("nil"))
+			continue
+		}
+		h.Write([]byte(fmt.Sprintf("%v", v)))
+	}
+	sum := h.Sum64()
+	h.Reset()
+
+	ptrs, ok := h.m[sum]
 	if !ok {
 		return nil, nil
-		//		return nil, fmt.Errorf("could not find sum '%d' (%v) in index %s", sum, values, h)
 	}
-
-	t = (*list.Element)(unsafe.Pointer(ptr))
-	return t, nil
+	result := make([]*list.Element, len(ptrs))
+	for i, p := range ptrs {
+		result[i] = (*list.Element)(unsafe.Pointer(p))
+	}
+	return result, nil
 }
 
 func (h *HashIndex) Truncate() {
-	h.m = make(map[uint64]uintptr)
+	h.m = make(map[uint64][]uintptr)
 }
 
 func (h *HashIndex) String() string {

--- a/engine/agnostic/source.go
+++ b/engine/agnostic/source.go
@@ -6,10 +6,10 @@ import (
 )
 
 type IndexSrc struct {
-	tuple   *list.Element
-	hasNext bool
-	rname   string
-	cols    []string
+	tuples []*list.Element
+	pos    int
+	rname  string
+	cols   []string
 }
 
 func NewHashIndexSource(index Index, alias string, p Predicate) (*IndexSrc, error) {
@@ -31,15 +31,12 @@ func NewHashIndexSource(index Index, alias string, p Predicate) (*IndexSrc, erro
 		return nil, fmt.Errorf("predicate %s is not a Eq predicate", p)
 	}
 
-	t, err := i.Get([]any{eq.right.Value(nil, nil)})
+	tuples, err := i.GetAll([]any{eq.right.Value(nil, nil)})
 	if err != nil {
 		return nil, fmt.Errorf("cannot create NewHashIndexSource(%s,%s): %s", index, p, err)
 	}
 
-	s.tuple = t
-	if t != nil {
-		s.hasNext = true
-	}
+	s.tuples = tuples
 	return s, nil
 }
 
@@ -48,15 +45,16 @@ func (s IndexSrc) String() string {
 }
 
 func (s *IndexSrc) HasNext() bool {
-	return s.hasNext
+	return s.pos < len(s.tuples)
 }
 
 func (s *IndexSrc) Next() *list.Element {
-	if !s.hasNext {
+	if s.pos >= len(s.tuples) {
 		return nil
 	}
-	s.hasNext = false
-	return s.tuple
+	e := s.tuples[s.pos]
+	s.pos++
+	return e
 }
 
 func (s *IndexSrc) Columns() []string {
@@ -64,10 +62,7 @@ func (s *IndexSrc) Columns() []string {
 }
 
 func (s *IndexSrc) EstimateCardinal() int64 {
-	if s.tuple != nil {
-		return 1
-	}
-	return 0
+	return int64(len(s.tuples))
 }
 
 type SeqScanSrc struct {


### PR DESCRIPTION
## Summary

- `HashIndex` stored a single `uintptr` per hash bucket, so every `Add()` for a key with duplicate values silently overwrote the previous pointer — only the last inserted row was ever returned
- Changed the map value to `[]uintptr` so all pointers for a given hash are kept; `Remove()` now filters the specific pointer out of the slice and only deletes the key when the slice empties
- Added `GetAll()` to `HashIndex` (and the `Index` interface) that returns every matching element for a hash key
- `IndexSrc` updated to hold a `[]*list.Element` slice + cursor instead of a single element, so index scans return all matching rows

## Test plan

- [ ] `go test ./...` passes (all existing tests green)
- [ ] New `TestHashIndexMultipleRowsSameFK` in `driver/driver_test.go`: inserts 3 child rows referencing the same FK value, queries `WHERE parent_id = 1`, asserts count == 3 — would have returned 1 before this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)